### PR TITLE
Set up Cursor Cloud dev environment (Ionic 3 / Node 8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`fireapp` is an **Ionic 3 / Angular 5** mobile web app (built with `@ionic/app-scripts` 3.1.9)
+that stores a "garde" list in a Firebase Realtime Database. There is a single frontend service
+(no backend in this repo).
+
+### Node version (critical)
+This legacy 2018 toolchain (`@ionic/app-scripts` 3.1.9, `node-sass` 4.7.2, TypeScript 2.6) does
+**not** work on modern Node. Use **Node 8.17.0** (installed via `nvm`). `node-sass` 4.7.2 only has
+prebuilt binaries up to Node 9.
+
+The sandbox ships `/exec-daemon/node` (Node 22) earlier in `PATH` than nvm, so `nvm use` alone is
+not enough. Node 8 is prepended to `PATH` in `~/.bashrc`, so **new login/interactive shells and new
+tmux sessions already get Node 8** (`node --version` should print `v8.17.0`). If you run a command in
+a stripped environment, prepend it manually:
+`export PATH="$HOME/.nvm/versions/node/v8.17.0/bin:$PATH"`.
+
+### Commands (run from repo root, see `package.json` scripts)
+- Lint: `npm run lint` (tslint; unused-import warnings are expected and do not fail the run)
+- Build: `npm run build` (outputs to `www/`)
+- Dev server: `npm run ionic:serve -- --nobrowser --address 0.0.0.0` → serves at
+  http://localhost:8100/ with live-reload/watch. Runs in the foreground; use tmux to keep it alive.
+
+### Firebase backend is dead (important gotcha)
+The hardcoded Firebase project in `src/app/app.module.ts` (`master-ad05d`) has been
+**deactivated** by Google, so add/list operations against it fail silently (clicking "Add!" does
+nothing visible and the list stays empty). This is an external dependency issue, not an environment
+bug. The frontend, build, and navigation all work. To exercise the list persistence feature you must
+plug your own Firebase config into `src/app/app.module.ts` (the README asks for exactly this).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `fireapp` (Ionic 3 / Angular 5 mobile web app) and documents it for future Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the required legacy Node version, lint/build/serve commands, and the deactivated Firebase gotcha.
- The update script installs deps with the Node 8 toolchain: `$HOME/.nvm/versions/node/v8.17.0/bin/npm install --no-audit --no-fund`.

## Environment details

This 2018 toolchain (`@ionic/app-scripts` 3.1.9, `node-sass` 4.7.2, TypeScript 2.6) requires **Node 8.17.0** (installed via nvm); `node-sass` 4.7.2 only ships prebuilt binaries up to Node 9. Node 8 is prepended to `PATH` via `~/.bashrc` so future shells resolve it ahead of the sandbox's Node 22.

## Verification

- `npm run lint` → passes (exit 0; unused-import warning only)
- `npm run build` → builds successfully into `www/`
- `npm run ionic:serve -- --nobrowser --address 0.0.0.0` → serves at http://localhost:8100/ (HTTP 200)
- Loaded the app in Chrome, typed into the "describe me" input, clicked "Add!", and navigated the Home/About/Contact tabs.

The hardcoded Firebase project (`master-ad05d`) has been deactivated by Google, so the list "Add" action does not persist. This is an external dependency issue (the README asks the user to supply their own Firebase config in `src/app/app.module.ts`), not an environment problem.

[ionic_fireapp_dev_demo.mp4](https://cursor.com/agents/bc-5166c7f3-b66b-4b14-986f-d1d45787c8fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fionic_fireapp_dev_demo.mp4)

[Home page loaded](https://cursor.com/agents/bc-5166c7f3-b66b-4b14-986f-d1d45787c8fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_page_loaded.webp)
[Text entered in input](https://cursor.com/agents/bc-5166c7f3-b66b-4b14-986f-d1d45787c8fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_input_text.webp)
[Contact tab renders](https://cursor.com/agents/bc-5166c7f3-b66b-4b14-986f-d1d45787c8fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_tab.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5166c7f3-b66b-4b14-986f-d1d45787c8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5166c7f3-b66b-4b14-986f-d1d45787c8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

